### PR TITLE
Have jest automatically read/glob all files within trajectory_tests and test them

### DIFF
--- a/common_tests/trajectory_tests/test_traj.json
+++ b/common_tests/trajectory_tests/test_traj.json
@@ -1,0 +1,1812 @@
+{
+  "ep_observations": [
+    [
+      {
+        "players": [
+          {
+            "position": [
+              1,
+              2
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": null
+          },
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": null
+          }
+        ],
+        "objects": [],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              1,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": null
+          },
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": null
+          }
+        ],
+        "objects": [],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              1,
+              1
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": null
+          },
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                3,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              1,
+              1
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                1,
+                1
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              1,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                1,
+                1
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              1,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                1,
+                1
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": null
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              1,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": null
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              1,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                3,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              1,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": null
+          },
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                3,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              2,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              1,
+              1
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": null
+          },
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              2,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              1,
+              2
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": null
+          },
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              2,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              1,
+              2
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": {
+              "name": "dish",
+              "position": [
+                1,
+                2
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": null
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              3,
+              1
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              1,
+              2
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "dish",
+              "position": [
+                1,
+                2
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": null
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              3,
+              2
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              2
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "dish",
+              "position": [
+                2,
+                2
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": null
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              3,
+              3
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": {
+              "name": "dish",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": null
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              3,
+              4
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": {
+              "name": "dish",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                3,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              3,
+              5
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": {
+              "name": "dish",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                3,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              3,
+              5
+            ]
+          }
+        ],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": {
+              "name": "soup",
+              "position": [
+                2,
+                1
+              ],
+              "state": [
+                "onion",
+                3,
+                5
+              ]
+            }
+          },
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                3,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "soup",
+              "position": [
+                2,
+                1
+              ],
+              "state": [
+                "onion",
+                3,
+                5
+              ]
+            }
+          },
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                3,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "soup",
+              "position": [
+                3,
+                1
+              ],
+              "state": [
+                "onion",
+                3,
+                5
+              ]
+            }
+          },
+          {
+            "position": [
+              3,
+              2
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                3,
+                2
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              3,
+              1
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": {
+              "name": "soup",
+              "position": [
+                3,
+                1
+              ],
+              "state": [
+                "onion",
+                3,
+                5
+              ]
+            }
+          },
+          {
+            "position": [
+              3,
+              2
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                3,
+                2
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              3,
+              2
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": {
+              "name": "soup",
+              "position": [
+                3,
+                2
+              ],
+              "state": [
+                "onion",
+                3,
+                5
+              ]
+            }
+          },
+          {
+            "position": [
+              2,
+              2
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                2,
+                2
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [],
+        "order_list": [
+          "onion",
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              3,
+              2
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": null
+          },
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": {
+              "name": "onion",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [],
+        "order_list": [
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              3,
+              2
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": null
+          },
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": null
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              1,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              3,
+              2
+            ],
+            "orientation": [
+              1,
+              0
+            ],
+            "held_object": {
+              "name": "tomato",
+              "position": [
+                3,
+                2
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              2,
+              2
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": null
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              1,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              2
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": {
+              "name": "tomato",
+              "position": [
+                2,
+                2
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              1,
+              2
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": null
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              1,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": {
+              "name": "tomato",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              1,
+              2
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": {
+              "name": "tomato",
+              "position": [
+                1,
+                2
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              1,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              1
+            ],
+            "orientation": [
+              0,
+              -1
+            ],
+            "held_object": {
+              "name": "tomato",
+              "position": [
+                2,
+                1
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              1,
+              2
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": {
+              "name": "tomato",
+              "position": [
+                1,
+                2
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              1,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              2
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": {
+              "name": "tomato",
+              "position": [
+                2,
+                2
+              ],
+              "state": null
+            }
+          },
+          {
+            "position": [
+              1,
+              2
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": {
+              "name": "tomato",
+              "position": [
+                1,
+                2
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              1,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "any"
+        ]
+      },
+      {
+        "players": [
+          {
+            "position": [
+              2,
+              2
+            ],
+            "orientation": [
+              0,
+              1
+            ],
+            "held_object": null
+          },
+          {
+            "position": [
+              1,
+              2
+            ],
+            "orientation": [
+              -1,
+              0
+            ],
+            "held_object": {
+              "name": "tomato",
+              "position": [
+                1,
+                2
+              ],
+              "state": null
+            }
+          }
+        ],
+        "objects": [
+          {
+            "name": "soup",
+            "position": [
+              2,
+              0
+            ],
+            "state": [
+              "onion",
+              1,
+              0
+            ]
+          },
+          {
+            "name": "soup",
+            "position": [
+              2,
+              3
+            ],
+            "state": [
+              "tomato",
+              1,
+              0
+            ]
+          }
+        ],
+        "order_list": [
+          "any"
+        ]
+      }
+    ]
+  ],
+  "ep_actions": [
+    [
+      [
+        [
+          0,
+          -1
+        ],
+        [
+          1,
+          0
+        ]
+      ],
+      [
+        [
+          -1,
+          0
+        ],
+        "interact"
+      ],
+      [
+        "interact",
+        [
+          -1,
+          0
+        ]
+      ],
+      [
+        [
+          1,
+          0
+        ],
+        [
+          0,
+          -1
+        ]
+      ],
+      [
+        [
+          0,
+          0
+        ],
+        "interact"
+      ],
+      [
+        [
+          1,
+          0
+        ],
+        [
+          1,
+          0
+        ]
+      ],
+      [
+        [
+          0,
+          -1
+        ],
+        "interact"
+      ],
+      [
+        "interact",
+        [
+          -1,
+          0
+        ]
+      ],
+      [
+        [
+          -1,
+          0
+        ],
+        [
+          -1,
+          0
+        ]
+      ],
+      [
+        [
+          0,
+          1
+        ],
+        [
+          0,
+          -1
+        ]
+      ],
+      [
+        "interact",
+        "interact"
+      ],
+      [
+        [
+          1,
+          0
+        ],
+        [
+          0,
+          1
+        ]
+      ],
+      [
+        [
+          1,
+          0
+        ],
+        "interact"
+      ],
+      [
+        [
+          0,
+          -1
+        ],
+        [
+          1,
+          0
+        ]
+      ],
+      [
+        "interact",
+        "interact"
+      ],
+      [
+        [
+          0,
+          0
+        ],
+        [
+          0,
+          0
+        ]
+      ],
+      [
+        "interact",
+        "interact"
+      ],
+      [
+        [
+          1,
+          0
+        ],
+        [
+          -1,
+          0
+        ]
+      ],
+      [
+        [
+          1,
+          0
+        ],
+        [
+          0,
+          1
+        ]
+      ],
+      [
+        [
+          0,
+          1
+        ],
+        "interact"
+      ],
+      [
+        [
+          0,
+          1
+        ],
+        [
+          -1,
+          0
+        ]
+      ],
+      [
+        "interact",
+        [
+          0,
+          -1
+        ]
+      ],
+      [
+        [
+          1,
+          0
+        ],
+        "interact"
+      ],
+      [
+        "interact",
+        [
+          0,
+          1
+        ]
+      ],
+      [
+        [
+          -1,
+          0
+        ],
+        [
+          -1,
+          0
+        ]
+      ],
+      [
+        [
+          0,
+          -1
+        ],
+        "interact"
+      ],
+      [
+        "interact",
+        "interact"
+      ],
+      [
+        [
+          0,
+          1
+        ],
+        "interact"
+      ],
+      [
+        "interact",
+        "interact"
+      ],
+      [
+        "interact",
+        "interact"
+      ]
+    ]
+  ],
+  "ep_rewards": [
+    [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      20,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  ],
+  "ep_dones": [
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false
+  ],
+  "ep_returns": [
+    20
+  ],
+  "ep_returns_sparse": [
+    20
+  ],
+  "ep_lengths": [
+    30
+  ],
+  "mdp_params": [
+    {
+      "layout_name": "mdp_test",
+      "cook_time": 5,
+      "start_order_list": [
+        "onion",
+        "any"
+      ],
+      "num_items_for_soup": 3,
+      "rew_shaping_params": null
+    }
+  ],
+  "env_params": [
+    {
+      "horizon": 100,
+      "start_state_fn": null
+    }
+  ]
+}

--- a/overcooked_ai_js/package.json
+++ b/overcooked_ai_js/package.json
@@ -24,6 +24,7 @@
     "canvas": "^2.5.0",
     "jest": "^23.6.0",
     "jest-canvas-mock": "^2.1.0",
+    "jest-expect-message": "^1.0.2",
     "jquery": "^3.4.1",
     "nodemon": "^1.19.1"
   },
@@ -33,10 +34,13 @@
     ]
   },
   "jest": {
+    "setupTestFrameworkScriptFile": "jest-expect-message",
     "setupFiles": [
       "jest-canvas-mock"
-    ], 
-    "verbose": false, 
-    "modulePaths":  ["<rootDir>"]
+    ],
+    "verbose": false,
+    "modulePaths": [
+      "<rootDir>"
+    ]
   }
 }


### PR DESCRIPTION
- Add jest-expect-message as a dependency so we can actually have nice custom error messages when things fail, that echo back the starting state, action, and mismatching result state 
- Add ability to auto-locate all trajectories within a certain file and run those as tests