### PR TITLE
updated onion/tomato vals for tutorials

### DIFF
--- a/src/overcooked_ai_py/data/layouts/tutorial_0.layout
+++ b/src/overcooked_ai_py/data/layouts/tutorial_0.layout
@@ -7,5 +7,8 @@
     "start_all_orders" : [
         { "ingredients" : ["onion", "onion", "onion"]}
     ],
-    "rew_shaping_params": None
+    "onion_value" : 21,
+    "tomato_value" : 13,
+    "onion_time" : 15,
+    "tomato_time" : 7
 }

--- a/src/overcooked_ai_py/data/layouts/tutorial_1.layout
+++ b/src/overcooked_ai_py/data/layouts/tutorial_1.layout
@@ -9,5 +9,8 @@
         { "ingredients" : ["onion", "tomato"]}
     ],
     "start_state" : {"players": [{"position": [4, 3], "orientation": [-1, 0], "held_object": None}, {"position": [4, 1], "orientation": [0, -1], "held_object": None}], "objects": [{"name": "soup", "position": [2, 2], "_ingredients": [{"name": "onion", "position": [2, 2]}, {"name": "onion", "position": [2, 2]}], "_cooking_tick": -1, "is_cooking": False, "is_ready": False, "is_idle": True, "cook_time": -1}], "bonus_orders": [], "all_orders": [{"ingredients": ["onion", "tomato"]}, {"ingredients": ["onion", "tomato", "tomato"]}]},
-    "rew_shaping_params": None
+    "onion_value" : 21,
+    "tomato_value" : 13,
+    "onion_time" : 15,
+    "tomato_time" : 7
 }

--- a/src/overcooked_ai_py/data/layouts/tutorial_2.layout
+++ b/src/overcooked_ai_py/data/layouts/tutorial_2.layout
@@ -8,7 +8,8 @@
     ],
     "start_bonus_orders" : [
     ],
-    "tomato_value" : 5,
-    "onion_value" : 10,
-    "rew_shaping_params": None
+    "onion_value" : 21,
+    "tomato_value" : 13,
+    "onion_time" : 15,
+    "tomato_time" : 7
 }

--- a/src/overcooked_ai_py/data/layouts/tutorial_3.layout
+++ b/src/overcooked_ai_py/data/layouts/tutorial_3.layout
@@ -10,5 +10,8 @@
         { "ingredients" : ["onion", "tomato", "tomato"]}
     ],
     "order_bonus" : float('inf'),
-    "rew_shaping_params": None
+    "onion_value" : 21,
+    "tomato_value" : 13,
+    "onion_time" : 15,
+    "tomato_time" : 7
 }


### PR DESCRIPTION
Some updates to the tutorial layouts I forgot to merge when we synched the overcooked-ai/human_aware_rl/overcooked-demo repos.

I think these changes belong in master rather that re-writing demo to use the old values, since these are the values we want for the tutorial going forward. Let me know if you disagree.