### PR TITLE
fix unpickling recipe bug

### DIFF
--- a/src/overcooked_ai_py/mdp/overcooked_mdp.py
+++ b/src/overcooked_ai_py/mdp/overcooked_mdp.py
@@ -25,9 +25,11 @@ class Recipe:
     _configured = False
     _conf = {}
     
-    def __new__(cls, ingredients):
+    def __new__(cls, ingredients=None):
         if not cls._configured:
             raise ValueError("Recipe class must be configured before recipes can be created")
+        if ingredients is None: # it is used for unpickling objects containing recipes
+            return super(Recipe, cls).__new__(cls)
         # Some basic argument verification
         if not ingredients or not hasattr(ingredients, '__iter__') or len(ingredients) == 0:
             raise ValueError("Invalid input recipe. Must be ingredients iterable with non-zero length")
@@ -43,6 +45,8 @@ class Recipe:
         return cls.ALL_RECIPES_CACHE[key]
 
     def __init__(self, ingredients):
+        if ingredients is None: # it is used for unpickling objects containing recipes
+            ingredients = tuple()
         self._ingredients = ingredients
 
     def __int__(self):
@@ -54,6 +58,9 @@ class Recipe:
         encoding = num_onions + (Recipe.MAX_NUM_INGREDIENTS + 1) * num_tomatoes
 
         return mixed_mask * encoding * mixed_shift + encoding
+
+    # def __setstate__(self):
+    # TODO: If unpickled recipes act weird copying here some logic from __new__ maybe could help
 
     def __hash__(self):
         return hash(self.ingredients)


### PR DESCRIPTION
Fix bug that appears when unpickling anything that contains a recipe (like loading planner). You can reproduce it doing the following steps:
1. Run ipython notebook with the current master code.
2. Declare human evaluator
```
from overcooked_ai_py.agents.benchmarking import AgentEvaluator, LayoutGenerator
mdp_gen_params = {"layout_name": 'cramped_room'}
mdp_fn = LayoutGenerator.mdp_gen_fn_from_dict(mdp_gen_params)
env_params = {"horizon": 1000}
agent_eval = AgentEvaluator(env_params=env_params, mdp_fn=mdp_fn)
```
3. Run evaluation on human model pair (to use planner)
4. Restart the kernel.
5. Do steps 2 and 3. On step 3 you should get an error.

```
trajectory_human_pair = agent_eval.evaluate_human_model_pair(num_games=3, display=False)
```
Example traceback:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-d93515dad6d8> in <module>
      3 print("Random pair rewards", trajectory_random_pair["ep_returns"])
      4 # Human agent does greedy actions without much cooperation
----> 5 trajectory_human_pair = agent_eval.evaluate_human_model_pair(num_games=3, display=False)
      6 print("Geedy human pair rewards", trajectory_human_pair["ep_returns"])

~/Desktop/programming/dev/overcooked_ai/src/overcooked_ai_py/agents/benchmarking.py in evaluate_human_model_pair(self, num_games, display, native_eval)
    116 
    117     def evaluate_human_model_pair(self, num_games=1, display=False, native_eval=False):
--> 118         a0 = GreedyHumanModel(self.env.mlam)
    119         a1 = GreedyHumanModel(self.env.mlam)
    120         agent_pair = AgentPair(a0, a1)

~/Desktop/programming/dev/overcooked_ai/src/overcooked_ai_py/mdp/overcooked_env.py in mlam(self)
     88             print("Computing MediumLevelActionManager")
     89             self._mlam = MediumLevelActionManager.from_pickle_or_compute(self.mdp, self.mlam_params,
---> 90                                                                   force_compute=False)
     91         return self._mlam
     92 

~/Desktop/programming/dev/overcooked_ai/src/overcooked_ai_py/planning/planners.py in from_pickle_or_compute(mdp, mlam_params, custom_filename, force_compute, info)
    799 
    800         try:
--> 801             mlam = MediumLevelActionManager.from_file(filename)
    802 
    803             if mlam.params != mlam_params or mlam.mdp != mdp:

~/Desktop/programming/dev/overcooked_ai/src/overcooked_ai_py/planning/planners.py in from_file(filename)
    787     @staticmethod
    788     def from_file(filename):
--> 789         return load_saved_action_manager(filename)
    790 
    791     @staticmethod

~/Desktop/programming/dev/overcooked_ai/src/overcooked_ai_py/data/planners/__init__.py in load_saved_action_manager(filename)
      5 def load_saved_action_manager(filename):
      6     with open(os.path.join(PLANNERS_DIR, filename), 'rb') as f:
----> 7         mlp_action_manager = pickle.load(f)
      8         return mlp_action_manager
      9 

TypeError: __new__() missing 1 required positional argument: 'ingredients'
```
Change in this PR works, but maybe there is something to add in the `__setstate__` method (mostly code from `__new__`) to make it even more bug-resilient.
An alternative way to deal with this bug is to make sure to never pickle anything that can contain a recipe by deleting all pickled object variables that could contain the recipe object e.g. soups state (self._recipe).