### PR TITLE
Layout metrics

### DIFF
--- a/src/overcooked_ai_py/agents/agent.py
+++ b/src/overcooked_ai_py/agents/agent.py
@@ -458,6 +458,26 @@ class GreedyHumanModel(Agent):
 
         return motion_goals
 
+class SampleAgent(Agent):
+    """ Agent that samples action using action_probs of multiple agents
+    """
+    def __init__(self, agents, agents_weights="uniform"):
+        if agents_weights == "uniform":
+            agents_weights = [1.0/len(agents)]*len(agents)
+        assert len(agents_weights) == len(agents)
+        self.weights = np.array(agents_weights)
+        self.agents = agents
+
+    def action(self, state):
+        action_probs = np.zeros(Action.NUM_ACTIONS)
+        for agent, weight in zip(self.agents, self.weights):
+            action_probs += np.array(agent.action(state)[1]["action_probs"])*weight
+        return Action.sample(action_probs), {"action_probs": action_probs}
+    """
+    """
+
+def add_random_play_to_agent(agent, random_play_fraction=0.1, does_random_interactions=False):
+    return SampleAgent([agent, RandomAgent(all_actions=does_random_interactions)], agents_weights=[1-random_play_fraction, random_play_fraction])
 
 # Deprecated. Need to fix Heuristic to work with the new MDP to reactivate Planning
 # class CoupledPlanningAgent(Agent):

--- a/src/overcooked_ai_py/mdp/layout_metrics.py
+++ b/src/overcooked_ai_py/mdp/layout_metrics.py
@@ -1,0 +1,75 @@
+from overcooked_ai_py.agents.agent import AgentPair, RandomAgent, GreedyHumanModel, add_random_play_to_agent
+from overcooked_ai_py.mdp.overcooked_env import OvercookedEnv
+from overcooked_ai_py.mdp.layout_generator import LayoutGenerator
+from overcooked_ai_py.agents.benchmarking import AgentEvaluator
+import itertools, copy
+import numpy as np
+
+DEFAULT_ENV_PARAMS = {"horizon": 1000}
+
+
+def _get_pairs_scores(agent_evaluator, pairs, num_games_per_pair=1):
+    return list(itertools.chain(list(agent_evaluator.evaluate_agent_pair(pair, num_games=num_games_per_pair)["ep_returns"] for pair in pairs)))
+
+def non_self_play_difficulty(mdp, agents=None, num_games_per_pair=1,
+                              num_games_per_non_self_play_pair=None,
+                              num_games_per_self_play_pair=None,
+                              env_params=None):
+    if num_games_per_non_self_play_pair is None:
+        num_games_per_non_self_play_pair = num_games_per_pair
+    if num_games_per_self_play_pair is None:
+        num_games_per_self_play_pair = num_games_per_pair
+    if env_params is None:
+        env_params = copy.deepcopy(DEFAULT_ENV_PARAMS)
+    
+    agent_eval = AgentEvaluator.from_mdp(mdp, env_params=env_params)
+
+    if agents is None:
+        # TODO: needs better agents - at least one that does any real coordination
+        agents = [RandomAgent(all_actions=True), GreedyHumanModel(agent_eval.env.mlam)]
+
+    assert len(agents) > 1
+    self_play_pairs = [AgentPair(agent, agent, allow_duplicate_agents=True) for agent in agents]
+    non_self_play_pairs = [AgentPair(agent1, agent2) for agent1, agent2 in itertools.combinations(agents, 2)]
+    
+    self_play_scores = _get_pairs_scores(agent_eval, self_play_pairs, num_games_per_self_play_pair)
+    non_self_play_scores = _get_pairs_scores(agent_eval, non_self_play_pairs, num_games_per_non_self_play_pair)
+
+    result = np.mean(self_play_scores)/np.mean(non_self_play_scores)
+    if np.isnan(result) or np.isinf(result):
+        return None
+    else:
+        return result
+
+
+
+def random_plays_difficulty(mdp, agent_pairs=None, num_games_per_pair=1,
+                                   num_games_per_non_randomized_pair=None,
+                                   num_games_per_randomized_pair=None,
+                                   random_plays_fraction=0.1, does_random_interactions=True,
+                                   env_params=None):
+    
+    if num_games_per_non_randomized_pair is None:
+        num_games_per_non_randomized_pair = num_games_per_pair
+    if num_games_per_randomized_pair is None:
+        num_games_per_randomized_pair = num_games_per_pair
+    if env_params is None:
+        env_params = copy.deepcopy(DEFAULT_ENV_PARAMS)
+
+    agent_eval = AgentEvaluator.from_mdp(mdp, env_params=env_params)
+    
+    if agent_pairs is None:
+        # TODO: needs better agents - at least one that does any real coordination
+        agent_pairs = [AgentPair(GreedyHumanModel(agent_eval.env.mlam), GreedyHumanModel(agent_eval.env.mlam))]
+    assert len(agent_pairs) > 0
+    non_randomized_agent_pairs = agent_pairs
+    randomized_agent_pairs = [AgentPair(*[add_random_play_to_agent(agent, random_plays_fraction, does_random_interactions=does_random_interactions)
+                               for agent in pair.agents], allow_duplicate_agents=True) for pair in agent_pairs]
+    
+    non_randomized_play_scores = _get_pairs_scores(agent_eval, non_randomized_agent_pairs, num_games_per_non_randomized_pair)
+    randomized_play_scores = _get_pairs_scores(agent_eval, randomized_agent_pairs, num_games_per_randomized_pair)
+    result =  np.mean(non_randomized_play_scores)/np.mean(randomized_play_scores)
+    if np.isnan(result) or np.isinf(result):
+        return None
+    else:
+        return result

--- a/src/overcooked_ai_py/utils.py
+++ b/src/overcooked_ai_py/utils.py
@@ -171,3 +171,18 @@ def read_layout_dict(layout_name):
 
 def is_iterable(obj):
     return isinstance(obj, Iterable)
+
+def invoke_until_result_satisfies_contition(condition, max_tries=None, exception=Exception):
+    ''' decorator; runs function until condition is satisfied or when number of tries reach max_tries (then it raises exception)
+    '''
+    def result_decorator(f):
+        def result_f(*args, **kwargs):
+            tries = 0
+            while (not max_tries or tries < max_tries):
+                result = f(*args, **kwargs)
+                if condition(result):
+                    return result
+                tries += 1
+            raise exception
+        return result_f
+    return result_decorator


### PR DESCRIPTION

Code for this issue: https://github.com/HumanCompatibleAI/overcooked_ai/issues/65
It adds basic layout metrics that inform about coordination difficulties. Those metrics would work ok with working agents that coordinate (currently RandomAgent and GreedyHumanModel are used, but none of them coordinates). Those metrics are not deterministic but variance can be decreased by increasing num_games_per_pair number at the cost of longer computing. They are also slow and agent dependent, on the other hand, they are universal.

example code that checks layout difficulty:
```
from overcooked_ai_py.mdp.layout_metrics import non_self_play_difficulty, random_plays_difficulty
from overcooked_ai_py.mdp.overcooked_mdp import OvercookedGridworld

mdp = OvercookedGridworld.from_layout_name("cramped_room")
print("num_games_per_pair", 1)
for i in range(3):
    print(non_self_play_difficulty(mdp, num_games_per_pair=1), random_plays_difficulty(mdp, num_games_per_pair=1))
print("num_games_per_pair", 5)
for i in range(3):
    print(non_self_play_difficulty(mdp, num_games_per_pair=5), random_plays_difficulty(mdp, num_games_per_pair=5))
print("num_games_per_pair", 20)
for i in range(3):
    print(non_self_play_difficulty(mdp, num_games_per_pair=20), random_plays_difficulty(mdp, num_games_per_pair=20))

```
result (actual logs with deleted other printouts like "Skipping trajectory consistency..."):
```
num_games_per_pair 1
0.8846153846153846 1.0
1.6428571428571428 23.0
2.875 1.263157894736842
num_games_per_pair 5
1.6764705882352942 1.1018518518518519
1.2777777777777777 1.6027397260273972
1.1734693877551021 1.297872340425532
num_games_per_pair 20
1.5931034482758621 1.3866279069767442
1.686131386861314 1.4234234234234233
1.0774647887323943 1.351123595505618
```
I think the high variance despite 20 games per agent pair comes from the fact that RandomAgent is random (and it is used only because of lack of a better default agent).
Those generated metrics can used to generate layout that passes some filtering function that depends on metric e.g.:
```
mdp_gen_params = {
    "inner_shape": [5, 4],
    "prop_empty": 0.8,
    "prop_feats": 0.2,
    "start_all_orders" : [
        { "ingredients" : ["onion", "onion", "onion"]}
    ],
    "recipe_values" : [20],
    "recipe_times" : [20],
    "display": False
}
filter_function = lambda mdp: random_plays_difficulty(mdp) > 1.5
mdp = LayoutGenerator.mdp_gen_fn_from_dict(mdp_gen_params, outer_shape=(5,4), filter_function=filter_function,
                                          max_searched_layouts=100)()
```

I'm not sure if layout metrics should be a separate module or part of some existing module/class. Currently, they are in a separate module.
I think that without a good, trained agent there is no point in merging this yet.