### PR TITLE
Layout Evaluator Changes

### DIFF
--- a/src/overcooked_ai_py/mdp/layout_evaluator.py
+++ b/src/overcooked_ai_py/mdp/layout_evaluator.py
@@ -14,7 +14,7 @@ UNDEFIND_LOCATION = "UND_L"
 # the undefined action
 UNDEFIND_ACTION = "UND_A"
 
-ENTROPY_RO = 5
+ENTROPY_RHO = 5
 
 
 import heapq
@@ -248,18 +248,18 @@ def connect_action_path(action_paths):
         total_path += path
     return total_path
 
-def calculate_entropy_of_path(path, ro):
+def calculate_entropy_of_path(path, rho):
     """
         Arguments:
             path (list): a list of tuble for locations of agent 0
-            ro: parameter used in calculation of entropy
+            rho: parameter used in calculation of entropy
         return:
             the calculated entropy of the path
-            entropy of a sequence of one action 'a' repeated 'n' times is -ln(n) + ln(ro)
+            entropy of a sequence of one action 'a' repeated 'n' times is -ln(n) + ln(rho)
             total entropy is the sum of all the sequences in the path
     """
     total_entropy = 0
-    const_entropy = np.log(ro)
+    const_entropy = np.log(rho)
     curr_length = 1
     curr_action = path[0]
 
@@ -1015,6 +1015,9 @@ def terrain_analysis(terrain_mtx, silent=True, best_only=True):
             details for conventions can be found at overcooked_ai_py.mdp.layout_generator
         silent (bool): whether to print the details
         best_only (bool): whether to only consider the best mla_node at each mla_hash
+    Returns:
+        a dictionary containing the stage score, various individual paths for both agents
+        to make a 3 onion soup, and these paths sorted by length
     """
     start_player_positions = [None, None]
 

--- a/src/overcooked_ai_py/mdp/layout_evaluator.py
+++ b/src/overcooked_ai_py/mdp/layout_evaluator.py
@@ -12,6 +12,8 @@ UNDEFIND_LOCATION = "UND_L"
 # the undefined action
 UNDEFIND_ACTION = "UND_A"
 
+ENTROPY_RO = 5
+
 import heapq
 
 

--- a/src/overcooked_ai_py/mdp/layout_evaluator.py
+++ b/src/overcooked_ai_py/mdp/layout_evaluator.py
@@ -17,8 +17,17 @@ ENTROPY_RO = 5
 import heapq
 
 
-def midpoint(point_0, point_1):
-    return tuple([(point_0[0] + point_1[0])//2, (point_0[1] + point_1[1])//2])
+def midpoint(point_0, point_1, terrain_matrix):
+    if point_0[0] == point_1[0] or point_0[1] == point_1[1]:
+        return tuple([(point_0[0] + point_1[0])//2, (point_0[1] + point_1[1])//2])
+    else:
+        # handling the diagonal handover
+        if terrain_matrix[point_0[0]][point_1[1]] == "X":
+            return tuple([point_0[0], point_1[1]])
+        elif terrain_matrix[point_1[0]][point_0[1]] == "X":
+            return tuple([point_1[0], point_0[1]])
+        else:
+            raise NotImplementedError("neither of the diagonal entries has a counter")
 
 def add_action_from_location(curr_loc, next_loc, actions):
     """
@@ -271,10 +280,10 @@ class OvercookedSearchNode:
             self.agent_1_path, self.num_counter_ops
         )
 
-    def successor(self, primary_agent_new_loc, counter_opposite_loc=None):
+    def successor(self, primary_agent_new_loc, counter_opposite_loc=None, terrain_mtx=None):
         successor_node = self.copy()
         if counter_opposite_loc:
-            counter_loc = midpoint(primary_agent_new_loc, counter_opposite_loc)
+            counter_loc = midpoint(primary_agent_new_loc, counter_opposite_loc, terrain_mtx)
             # interact to get the iter onto the counter
             successor_node.update_primary_agent_loc(counter_loc, counter_loc)
             # change control
@@ -556,7 +565,7 @@ def uniform_cost_search(walk_graph, handover_graph, terrain_mtx, agent_locations
                     other_agent_walk_dist = shortest_walk_dist(walk_graph, other_agent_loc, suc_loc, terrain_mtx)
                     if other_agent_walk_dist != INFINITY:
                         # give control over to the other agent, and become the other agent by "taking its place on the map"\
-                        newNode = curNode.successor(suc_loc, loc)
+                        newNode = curNode.successor(suc_loc, loc, terrain_mtx)
                         fringe.push(newNode, newNode.path_length())
     return res
 

--- a/src/overcooked_ai_py/mdp/layout_evaluator.py
+++ b/src/overcooked_ai_py/mdp/layout_evaluator.py
@@ -117,6 +117,34 @@ def path_to_actions(path_0, path_1, terrain_mtx):
     assert len(actions_0) == len(actions_1), " resulting actions should have the same length. Please pad if otherwise"
     return actions_0, actions_1
 
+def calculate_entropy_of_path(path, ro):
+    total_entropy = 0
+    const_entropy = np.log(ro)
+    curr_length = 1
+    curr_action = path[0]
+
+    # calculate and add entropy for each sequence of actions
+
+    for action in path[1:]:
+        if action == curr_action:
+            curr_length += 1
+        else:
+            if curr_action == UNDEFIND_ACTION:
+                curr_length = 1
+                curr_action = action
+                continue
+            entropy = -np.log(curr_length) + const_entropy
+            total_entropy += entropy
+            curr_length = 1
+            curr_action = action
+
+    # add entropy for last sequence of actions
+    if curr_action != UNDEFIND_ACTION:
+        entropy = -np.log(curr_length) + const_entropy
+        total_entropy += entropy
+
+    return total_entropy
+
 
 
 
@@ -718,6 +746,9 @@ def terrain_analysis(terrain_mtx, silent = True):
         p1_starting = (p1_starting_pre[1], p1_starting_pre[0])
 
     stage_score = []
+
+    player_1_action_path = []
+    player_2_action_path = []
 
     p0_i, p0_j = p0_starting
     p1_i, p1_j = p1_starting

--- a/src/overcooked_ai_py/mdp/overcooked_env.py
+++ b/src/overcooked_ai_py/mdp/overcooked_env.py
@@ -75,9 +75,11 @@ class OvercookedEnv(object):
         self.horizon = horizon
         self._mlam = None
         self._mp = None
+        self.mdp = None
         self.mlam_params = mlam_params
         assert not (start_state_fn and litter_params), "litter params will change start state fn, and thus we can't have both"
         if litter_params:
+            # this extra layer of shelding is necessary to define the function without self.mdp being initialized
             self.start_state_fn = lambda: OvercookedGridworld.get_litter_start_state_fn(self.mdp, **litter_params)()
         else:
             self.start_state_fn = start_state_fn

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -1,5 +1,5 @@
 import unittest
-from overcooked_ai_py.mdp.layout_evaluator import terrain_analysis
+from overcooked_ai_py.mdp.layout_evaluator import terrain_analysis, path_to_actions, UNDEFIND_ACTION
 from overcooked_ai_py.mdp.overcooked_mdp import OvercookedGridworld
 
 
@@ -27,6 +27,53 @@ class TestHandoverEvaluation(unittest.TestCase):
     def test_0(self):
         terrain_analysis(self.divided_mtx, False)
 
+
+class TestMotionExtractor(unittest.TestCase):
+
+    def setUp(self):
+        self.divided_mtx = [
+            ['X', 'P', 'X', 'X', 'X'],
+            ['O', '2', 'X', ' ', 'O'],
+            ['X', ' ', 'X', '1', 'X'],
+            ['X', 'D', 'X', 'S', 'X'],
+        ]
+
+    def test_onion_pickup_2(self):
+        # basic motion test 1
+        path_0 = ['UND', 'UND']
+        path_1 = [(1, 1), (1, 0)]
+        self.assertEqual(path_to_actions(path_0, path_1, self.divided_mtx), (
+            [UNDEFIND_ACTION, UNDEFIND_ACTION],
+            [(-1, 0), 'interact']
+        ))
+
+    def test_onion_pickup_1(self):
+        # basic motion test 2
+        path_0 = [(2, 3), (1, 3), (1, 4)]
+        path_1 = ['UND', 'UND', 'UND']
+        self.assertEqual(path_to_actions(path_0, path_1, self.divided_mtx), (
+            [(0, -1), (1, 0), 'interact'],
+            [UNDEFIND_ACTION, UNDEFIND_ACTION, UNDEFIND_ACTION]
+        ))
+
+
+    def test_onion_drop_1(self):
+        # this tests counter handover
+        path_0 = [(1, 3), (1, 2), 'UND', 'UND']
+        path_1 = ['UND', (1, 2), (1, 1), (0, 1)]
+        self.assertEqual(path_to_actions(path_0, path_1, self.divided_mtx), (
+            [(-1, 0), 'interact', UNDEFIND_ACTION, UNDEFIND_ACTION, UNDEFIND_ACTION],
+            [UNDEFIND_ACTION, UNDEFIND_ACTION, 'interact', (0, -1), 'interact']
+        ))
+
+    def test_dish_pickup_1(self):
+        # this test abbreviation of additional movement because of natural agent facing
+        path_0 = ['UND', 'UND', 'UND']
+        path_1 = [(1, 1), (2, 1), (3, 1)]
+        self.assertEqual(path_to_actions(path_0, path_1, self.divided_mtx), (
+            [UNDEFIND_ACTION, UNDEFIND_ACTION],
+            [(0, 1), 'interact']
+        ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -466,7 +466,6 @@ class TestMotionExtractorRealMDP(unittest.TestCase):
 
 
     def test_counter_pre_movement(self):
-        # TODO: making sure agent "1" moves to (1, 1) to receive the soup
         divided_counter_pre_mtx = [
             ['X', 'P', 'X', 'X', 'X', 'X'],
             ['X', ' ', 'X', ' ', ' ', 'O'],
@@ -477,7 +476,6 @@ class TestMotionExtractorRealMDP(unittest.TestCase):
         self.mtx_test_helper(divided_counter_pre_mtx, verbose=True)
 
     def test_connected(self):
-        # TODO: This actually signals one of the problem we should address: the non-acting agent should move out of the way
         connected_mtx = [
             ['X', 'P', 'X', 'X', 'X', 'X'],
             ['O', ' ', ' ', ' ', ' ', 'O'],
@@ -488,7 +486,6 @@ class TestMotionExtractorRealMDP(unittest.TestCase):
 
 
     def test_small_keyhole(self):
-        # TODO: We should get this case to pass as well, then we are good to go
         small_keyhole_mtx = [
             ['X', 'P', 'X', 'X', 'X', 'X'],
             ['O', ' ', ' ', ' ', ' ', 'O'],

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 from overcooked_ai_py.mdp.layout_evaluator import terrain_analysis, path_to_actions, \
     UNDEFIND_ACTION, remove_extra_action, add_action_from_location, calculate_entropy_of_path, \
-    ENTROPY_RO, path_to_actions_with_padding, graph_from_terrain, shortest_walk_path
+    ENTROPY_RHO, path_to_actions_with_padding, graph_from_terrain, shortest_walk_path
 
 from overcooked_ai_py.mdp.overcooked_env import OvercookedEnv
 from overcooked_ai_py.mdp.overcooked_mdp import OvercookedGridworld
@@ -260,11 +260,11 @@ class TestEntropyComparison(unittest.TestCase):
         path_undefined_at_end = [(0, 1), (0, 1), (1, 0), 'interact', 'UND_A', 'UND_A']
         path_undefined_at_start = ['UND_A', 'UND_A', (0, 1), (0, 1), (1, 0), 'interact']
 
-        entropy = -np.log(2) - np.log(1) - np.log(1) + 3 * np.log(ENTROPY_RO)
+        entropy = -np.log(2) - np.log(1) - np.log(1) + 3 * np.log(ENTROPY_RHO)
 
-        self.assertAlmostEqual(calculate_entropy_of_path(path, ENTROPY_RO), entropy)
-        self.assertAlmostEqual(calculate_entropy_of_path(path_undefined_at_end, ENTROPY_RO), entropy)
-        self.assertAlmostEqual(calculate_entropy_of_path(path_undefined_at_start, ENTROPY_RO), entropy)
+        self.assertAlmostEqual(calculate_entropy_of_path(path, ENTROPY_RHO), entropy)
+        self.assertAlmostEqual(calculate_entropy_of_path(path_undefined_at_end, ENTROPY_RHO), entropy)
+        self.assertAlmostEqual(calculate_entropy_of_path(path_undefined_at_start, ENTROPY_RHO), entropy)
 
     def test_entropy_comparison_basic(self):
         # This tests entropy comparison for some basic variation in layouts
@@ -275,8 +275,8 @@ class TestEntropyComparison(unittest.TestCase):
         path_1 = [(0, 1), (0, 1), (0, 1), (0, 1), (1, 0), (1, 0),
                   (1, 0), (1, 0), (0, -1), (0, -1), (0, -1), (0, -1)]
 
-        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RO)
-        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RO)
+        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RHO)
+        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RHO)
 
         self.assertGreater(entropy_0, entropy_1)
 
@@ -292,8 +292,8 @@ class TestEntropyComparison(unittest.TestCase):
         path_1 = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (1, 0),
                   (1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1)]
 
-        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RO)
-        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RO)
+        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RHO)
+        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RHO)
 
         self.assertGreater(entropy_0, entropy_1)
 
@@ -309,8 +309,8 @@ class TestEntropyComparison(unittest.TestCase):
         path_1 = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (1, 0),
                   (1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1)]
 
-        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RO)
-        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RO)
+        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RHO)
+        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RHO)
 
         self.assertGreater(entropy_0, entropy_1)
 
@@ -325,8 +325,8 @@ class TestEntropyComparison(unittest.TestCase):
         path_1 = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (1, 0),
                   (1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1)]
 
-        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RO)
-        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RO)
+        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RHO)
+        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RHO)
 
         self.assertGreater(entropy_0, entropy_1)
 
@@ -343,8 +343,8 @@ class TestEntropyComparison(unittest.TestCase):
         path_1 = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (1, 0),
                   (1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1)]
 
-        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RO)
-        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RO)
+        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RHO)
+        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RHO)
 
         #self.assertGreater(entropy_0, entropy_1)
 
@@ -398,7 +398,7 @@ class TestEntropyComparison(unittest.TestCase):
         # calculate and save entropies of each path
         entropies = {}
         for path in paths_to_compare:
-            entropies[path] = calculate_entropy_of_path(paths_to_compare[path], ENTROPY_RO)
+            entropies[path] = calculate_entropy_of_path(paths_to_compare[path], ENTROPY_RHO)
 
         print(entropies)
 
@@ -417,8 +417,8 @@ class TestEntropyComparison(unittest.TestCase):
 
         # calculates and stores the entropies of each full action path
         for path in paths:
-            entropies[path] = calculate_entropy_of_path(paths[path][0], ENTROPY_RO) + \
-                              calculate_entropy_of_path(paths[path][1], ENTROPY_RO)
+            entropies[path] = calculate_entropy_of_path(paths[path][0], ENTROPY_RHO) + \
+                              calculate_entropy_of_path(paths[path][1], ENTROPY_RHO)
 
         print(entropies)
 

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -27,8 +27,19 @@ class TestHandoverEvaluation(unittest.TestCase):
         ]
         print(self.divided_mtx)
 
-    def test_0(self):
+        self.diagnoal_divided_mtx = [
+            ['X', 'X', 'X', 'X', 'S', 'X'],
+            ['X', 'X', 'X', ' ', '1', 'O'],
+            ['P', '2', ' ', 'X', 'X', 'X'],
+            ['X', 'D', 'X', 'X', 'X', 'X'],
+        ]
+        print(self.diagnoal_divided_mtx)
+
+    def test_simple(self):
         terrain_analysis(self.divided_mtx, False)
+
+    def test_diagonal(self):
+        terrain_analysis(self.diagnoal_divided_mtx, False)
 
 
 class TestMotionExtractor(unittest.TestCase):

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -120,6 +120,16 @@ class TestMotionExtractor(unittest.TestCase):
             [UNDEFIND_ACTION, UNDEFIND_ACTION, 'interact', (0, -1), 'interact']
         ))
 
+    def test_dish_serving(self):
+        # this tests counter handover in the other direction
+        # this tests the border cases for remove_extra_action
+        path_0 = ['UND_L', (1, 2), (1, 3), (2, 3), (3, 3)]
+        path_1 = [(1, 1), (1, 2), 'UND_L', 'UND_L', 'UND_L']
+        self.assertEqual(path_to_actions(path_0, path_1, self.divided_mtx), (
+            [UNDEFIND_ACTION, UNDEFIND_ACTION, 'interact', (0, 1), 'interact'],
+            [(1, 0), 'interact', UNDEFIND_ACTION, UNDEFIND_ACTION, UNDEFIND_ACTION]
+        ))
+
     def test_dish_pickup_1(self):
         # this test abbreviation of additional movement because of natural agent facing
         path_0 = ['UND_L', 'UND_L', 'UND_L']

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -455,6 +455,7 @@ class TestMotionExtractorRealMDP(unittest.TestCase):
                 self.assertTrue(sparse_rew == 20, "the action paths did not successfully result in soups in the end")
 
     def test_divided(self):
+        # This should aready pass
         divided_mtx = [
             ['X', 'P', 'X', 'X', 'X', 'X'],
             ['O', ' ', 'X', ' ', ' ', 'O'],
@@ -462,6 +463,18 @@ class TestMotionExtractorRealMDP(unittest.TestCase):
             ['X', 'D', 'X', 'S', 'X', 'X'],
         ]
         self.mtx_test_helper(divided_mtx, verbose=True)
+
+
+    def test_counter_pre_movement(self):
+        # TODO: making sure agent "1" moves to (1, 1) to receive the soup
+        divided_counter_pre_mtx = [
+            ['X', 'P', 'X', 'X', 'X', 'X'],
+            ['X', ' ', 'X', ' ', ' ', 'O'],
+            ['X', ' ', 'X', 'X', ' ', 'X'],
+            ['X', '1', 'X', 'X', '2', 'X'],
+            ['X', 'D', 'X', 'X', 'S', 'X'],
+        ]
+        self.mtx_test_helper(divided_counter_pre_mtx, verbose=True)
 
     def test_connected(self):
         # TODO: This actually signals one of the problem we should address: the non-acting agent should move out of the way

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -3,17 +3,7 @@ import numpy as np
 from overcooked_ai_py.mdp.layout_evaluator import terrain_analysis, path_to_actions, \
     UNDEFIND_ACTION, remove_extra_action, add_action_from_location, calculate_entropy_of_path, \
     ENTROPY_RO
-from overcooked_ai_py.mdp.overcooked_mdp import OvercookedGridworld
 
-
-# class TestSimpleEvaluation(unittest.TestCase):
-#
-#     def setUp(self):
-#         self.cramped_room_terrain_mtx = OvercookedGridworld.from_layout_name("cramped_room").terrain_mtx
-#         print(self.cramped_room_terrain_mtx)
-#
-#     def test_0(self):
-#         terrain_analysis(self.cramped_room_terrain_mtx, False)
 
 class TestHandoverEvaluation(unittest.TestCase):
 
@@ -359,6 +349,7 @@ class TestEntropyComparison(unittest.TestCase):
                               calculate_entropy_of_path(paths[path][1], ENTROPY_RO)
 
         print(entropies)
+
 
 
 

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -1,6 +1,7 @@
 import unittest
+import numpy as np
 from overcooked_ai_py.mdp.layout_evaluator import terrain_analysis, path_to_actions, \
-    UNDEFIND_ACTION, remove_extra_action, add_action_from_location
+    UNDEFIND_ACTION, remove_extra_action, add_action_from_location, calculate_entropy_of_path
 from overcooked_ai_py.mdp.overcooked_mdp import OvercookedGridworld
 
 
@@ -138,6 +139,62 @@ class TestMotionExtractor(unittest.TestCase):
             [UNDEFIND_ACTION, UNDEFIND_ACTION],
             [(0, 1), 'interact']
         ))
+
+class TestEntropyComparison(unittest.TestCase):
+    def setUp(self):
+        self.divided_mtx_basic = [
+            ['X', 'P', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X'],
+            ['X', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', 'X'],
+            ['D', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', 'X'],
+            ['X', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', 'X'],
+            ['X', ' ', ' ', ' ', ' ', ' ', ' ', ' ', '1', 'X'],
+            ['X', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', 'X'],
+            ['X', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', 'X'],
+            ['X', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', 'O'],
+            ['X', ' ', '2', ' ', ' ', ' ', ' ', ' ', ' ', 'X'],
+            ['X', 'X', 'D', 'X', 'X', 'X', 'X', 'S', 'X', 'X']
+        ]
+        self.divided_mtx_center_counter = [
+            ['X', 'P', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X'],
+            ['X', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', 'X'],
+            ['D', ' ', 'X', 'X', 'X', 'X', 'X', 'X', ' ', 'X'],
+            ['X', ' ', 'X', 'X', 'X', 'X', 'X', 'X', ' ', 'X'],
+            ['X', ' ', 'X', 'X', 'X', 'X', 'X', 'X', '1', 'X'],
+            ['X', ' ', 'X', 'X', 'X', 'X', 'X', 'X', ' ', 'X'],
+            ['X', ' ', 'X', 'X', 'X', 'X', 'X', 'X', ' ', 'X'],
+            ['X', ' ', 'X', 'X', 'X', 'X', 'X', 'X', ' ', 'O'],
+            ['X', ' ', '2', ' ', ' ', ' ', ' ', ' ', ' ', 'X'],
+            ['X', 'X', 'D', 'X', 'X', 'X', 'X', 'S', 'X', 'X']
+        ]
+
+        self.divided_mtx_keyhole_maze = [
+            ['X', 'P', 'X', 'X', 'X', 'X', 'X', 'X', 'X', 'X'],
+            ['X', ' ', 'X', ' ', ' ', ' ', ' ', 'X', ' ', 'X'],
+            ['D', ' ', 'X', ' ', 'X', 'X', ' ', 'X', ' ', 'X'],
+            ['X', ' ', 'X', ' ', 'X', 'X', ' ', 'X', ' ', 'X'],
+            ['X', ' ', 'X', ' ', 'X', 'X', ' ', 'X', '1', 'X'],
+            ['X', ' ', 'X', ' ', 'X', 'X', ' ', 'X', ' ', 'X'],
+            ['X', ' ', 'X', ' ', 'X', 'X', ' ', 'X', ' ', 'X'],
+            ['X', ' ', 'X', ' ', 'X', 'X', ' ', 'X', ' ', 'O'],
+            ['X', ' ', '2', ' ', 'X', 'X', ' ', ' ', ' ', 'X'],
+            ['X', 'X', 'D', 'X', 'X', 'X', 'X', 'S', 'X', 'X']
+        ]
+
+    def test_entropy_calculation(self):
+        ro = 5
+
+        path = [(0, 1), (0, 1), (1, 0), 'interact']
+        path_undefined_at_end = [(0, 1), (0, 1), (1, 0), 'interact', 'UND_A', 'UND_A']
+        path_undefined_at_start = ['UND_A', 'UND_A', (0, 1), (0, 1), (1, 0), 'interact']
+
+        entropy = -np.log(2) - np.log(1) - np.log(1) + 3 * np.log(ro)
+
+        self.assertAlmostEqual(calculate_entropy_of_path(path, ro), entropy)
+        self.assertAlmostEqual(calculate_entropy_of_path(path_undefined_at_end, ro), entropy)
+        self.assertAlmostEqual(calculate_entropy_of_path(path_undefined_at_start, ro), entropy)
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -1,5 +1,6 @@
 import unittest
-from overcooked_ai_py.mdp.layout_evaluator import terrain_analysis, path_to_actions, UNDEFIND_ACTION
+from overcooked_ai_py.mdp.layout_evaluator import terrain_analysis, path_to_actions, \
+    UNDEFIND_ACTION, remove_extra_action, add_action_from_location
 from overcooked_ai_py.mdp.overcooked_mdp import OvercookedGridworld
 
 
@@ -32,15 +33,68 @@ class TestMotionExtractor(unittest.TestCase):
 
     def setUp(self):
         self.divided_mtx = [
-            ['X', 'P', 'X', 'X', 'X'],
-            ['O', '2', 'X', ' ', 'O'],
-            ['X', ' ', 'X', '1', 'X'],
-            ['X', 'D', 'X', 'S', 'X'],
+            ['X', 'P', 'X', 'X', 'X', 'X'],
+            ['O', '2', 'X', ' ', ' ', 'O'],
+            ['X', ' ', 'X', '1', ' ', 'X'],
+            ['X', 'D', 'X', 'S', 'X', 'X'],
         ]
+    def test_remove_extra(self):
+
+        # test removing extra action for
+        # ['X', 'X', 'X', 'X']
+        # ['X', '1', ' ', 'O']
+        # ['X', 'X', 'X', 'X']
+        # vs
+        # ['X', 'X', 'O', 'X']
+        # ['X', '1', ' ', 'X']
+        # ['X', 'X', 'X', 'X']
+
+        actions_remove = [(1, 0), (1, 0), 'interact']
+        self.assertEqual(remove_extra_action(actions_remove), [(1,0), 'interact'])
+
+        actions_no_remove = [(1, 0), (0, -1), 'interact']
+        self.assertEqual(remove_extra_action(actions_no_remove), [(1, 0), (0, -1), 'interact'])
+
+    def test_add_action(self):
+
+        # row 1 of terrain
+        # ['O', ' ', 'X', ' ', 'P']
+        # test addition of actions for agent picking up from counter (covers all cases)
+
+        # no movement = no action
+        actions = []
+        curr_loc = 'UND_L'
+        next_loc = 'UND_L'
+        add_action_from_location(curr_loc, next_loc, actions)
+        self.assertEqual(actions, [])
+
+        # first of two actions that signify counter picking up
+        curr_loc = next_loc
+        next_loc = (1, 3)
+        add_action_from_location(curr_loc, next_loc, actions)
+        self.assertEqual(actions, ['UND_A'])
+
+        # second of two actions that signify counter picking up
+        curr_loc = next_loc
+        next_loc = (1, 4)
+        add_action_from_location(curr_loc, next_loc, actions)
+        self.assertEqual(actions, ['interact'])
+
+        # real movement action
+        curr_loc = next_loc
+        next_loc = (1, 5)
+        add_action_from_location(curr_loc, next_loc, actions)
+        self.assertEqual(actions, ['interact', (1, 0)])
+
+        # stop moving because of interaction
+        curr_loc = next_loc
+        next_loc = 'UND_L'
+        add_action_from_location(curr_loc, next_loc, actions)
+        self.assertEqual(actions, ['interact', (1, 0), 'interact'])
 
     def test_onion_pickup_2(self):
         # basic motion test 1
-        path_0 = ['UND', 'UND']
+        path_0 = ['UND_L', 'UND_L']
         path_1 = [(1, 1), (1, 0)]
         self.assertEqual(path_to_actions(path_0, path_1, self.divided_mtx), (
             [UNDEFIND_ACTION, UNDEFIND_ACTION],
@@ -49,8 +103,8 @@ class TestMotionExtractor(unittest.TestCase):
 
     def test_onion_pickup_1(self):
         # basic motion test 2
-        path_0 = [(2, 3), (1, 3), (1, 4)]
-        path_1 = ['UND', 'UND', 'UND']
+        path_0 = [(2, 3), (1, 3), (1, 4), (1, 5)]
+        path_1 = ['UND_L', 'UND_L', 'UND_L', 'UND_L']
         self.assertEqual(path_to_actions(path_0, path_1, self.divided_mtx), (
             [(0, -1), (1, 0), 'interact'],
             [UNDEFIND_ACTION, UNDEFIND_ACTION, UNDEFIND_ACTION]
@@ -59,8 +113,8 @@ class TestMotionExtractor(unittest.TestCase):
 
     def test_onion_drop_1(self):
         # this tests counter handover
-        path_0 = [(1, 3), (1, 2), 'UND', 'UND']
-        path_1 = ['UND', (1, 2), (1, 1), (0, 1)]
+        path_0 = [(1, 4), (1, 3), (1, 2), 'UND_L', 'UND_L']
+        path_1 = ['UND_L', 'UND_L', (1, 2), (1, 1), (0, 1)]
         self.assertEqual(path_to_actions(path_0, path_1, self.divided_mtx), (
             [(-1, 0), 'interact', UNDEFIND_ACTION, UNDEFIND_ACTION, UNDEFIND_ACTION],
             [UNDEFIND_ACTION, UNDEFIND_ACTION, 'interact', (0, -1), 'interact']
@@ -68,7 +122,7 @@ class TestMotionExtractor(unittest.TestCase):
 
     def test_dish_pickup_1(self):
         # this test abbreviation of additional movement because of natural agent facing
-        path_0 = ['UND', 'UND', 'UND']
+        path_0 = ['UND_L', 'UND_L', 'UND_L']
         path_1 = [(1, 1), (2, 1), (3, 1)]
         self.assertEqual(path_to_actions(path_0, path_1, self.divided_mtx), (
             [UNDEFIND_ACTION, UNDEFIND_ACTION],

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -1,7 +1,8 @@
 import unittest
 import numpy as np
 from overcooked_ai_py.mdp.layout_evaluator import terrain_analysis, path_to_actions, \
-    UNDEFIND_ACTION, remove_extra_action, add_action_from_location, calculate_entropy_of_path
+    UNDEFIND_ACTION, remove_extra_action, add_action_from_location, calculate_entropy_of_path, \
+    ENTROPY_RO
 from overcooked_ai_py.mdp.overcooked_mdp import OvercookedGridworld
 
 
@@ -182,28 +183,114 @@ class TestEntropyComparison(unittest.TestCase):
 
     def test_entropy_calculation(self):
         # This tests the calculate_entropy_of_path helper function
-        ro = 5
-
         path = [(0, 1), (0, 1), (1, 0), 'interact']
         path_undefined_at_end = [(0, 1), (0, 1), (1, 0), 'interact', 'UND_A', 'UND_A']
         path_undefined_at_start = ['UND_A', 'UND_A', (0, 1), (0, 1), (1, 0), 'interact']
 
-        entropy = -np.log(2) - np.log(1) - np.log(1) + 3 * np.log(ro)
+        entropy = -np.log(2) - np.log(1) - np.log(1) + 3 * np.log(ENTROPY_RO)
 
-        self.assertAlmostEqual(calculate_entropy_of_path(path, ro), entropy)
-        self.assertAlmostEqual(calculate_entropy_of_path(path_undefined_at_end, ro), entropy)
-        self.assertAlmostEqual(calculate_entropy_of_path(path_undefined_at_start, ro), entropy)
+        self.assertAlmostEqual(calculate_entropy_of_path(path, ENTROPY_RO), entropy)
+        self.assertAlmostEqual(calculate_entropy_of_path(path_undefined_at_end, ENTROPY_RO), entropy)
+        self.assertAlmostEqual(calculate_entropy_of_path(path_undefined_at_start, ENTROPY_RO), entropy)
+
+    def test_entropy_comparison_basic(self):
+        # This tests entropy comparison for some basic variation in layouts
+
+        # same number of segments (3) and total path length (12)
+        path_0 = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (1, 0),
+                  (1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1)]
+        path_1 = [(0, 1), (0, 1), (0, 1), (0, 1), (1, 0), (1, 0),
+                  (1, 0), (1, 0), (0, -1), (0, -1), (0, -1), (0, -1)]
+
+        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RO)
+        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RO)
+
+        self.assertGreater(entropy_0, entropy_1)
+
+        print('same # segments and path length')
+        print('----------------------------------------')
+        print('5 2 5:', entropy_0)
+        print('4 4 4:', entropy_1)
+        print()
+
+        # different number of segments (adding a segment to the end)
+        path_0 = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (1, 0),
+                  (1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1), (1, 0), (1, 0)]
+        path_1 = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (1, 0),
+                  (1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1)]
+
+        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RO)
+        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RO)
+
+        self.assertGreater(entropy_0, entropy_1)
+
+        print('same path but one has an extra segment')
+        print('----------------------------------------')
+        print('5 2 5 2:', entropy_0)
+        print('5 2 5:', entropy_1)
+        print()
+
+        # different number of segments with same path length
+        path_0 = [(0, 1), (0, 1), (0, 1), (1, 0), (1, 0), (0, -1),
+                  (0, -1), (0, -1), (0, 1), (0, 1), (0, 1), (0, 1)]
+        path_1 = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (1, 0),
+                  (1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1)]
+
+        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RO)
+        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RO)
+
+        self.assertGreater(entropy_0, entropy_1)
+
+        print('diff # segments with same path length')
+        print('----------------------------------------')
+        print('3 2 3 4:', entropy_0)
+        print('5 2 5:', entropy_1)
+        print()
+
+        # same number of segments with different path length
+        path_0 = [(0, 1), (0, 1), (0, 1), (1, 0), (1, 0), (0, -1), (0, -1), (0, -1)]
+        path_1 = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (1, 0),
+                  (1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1)]
+
+        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RO)
+        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RO)
+
+        self.assertGreater(entropy_0, entropy_1)
+
+        print('same # segments with diff path length')
+        print('----------------------------------------')
+        print('3 2 3:', entropy_0)
+        print('5 2 5:', entropy_1)
+        print()
+
+        # different number of segments (adding a segment to the end with length > ro (5))
+        path_0 = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (1, 0),
+                  (1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1),
+                  (1, 0), (1, 0), (1, 0), (1, 0), (1, 0), (1, 0)]
+        path_1 = [(0, 1), (0, 1), (0, 1), (0, 1), (0, 1), (1, 0),
+                  (1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1)]
+
+        entropy_0 = calculate_entropy_of_path(path_0, ENTROPY_RO)
+        entropy_1 = calculate_entropy_of_path(path_1, ENTROPY_RO)
+
+        #self.assertGreater(entropy_0, entropy_1)
+
+        print('same path but one has extra segment > ro (5)')
+        print('----------------------------------------')
+        print('5 2 5 6:', entropy_0)
+        print('5 2 5:', entropy_1)
+        print()
 
     def test_entropy_comparison_onion_dropoff(self):
         # This tests how entropy compares for the onion pickup task for three different layouts
 
-        basic = [(-1, 0), (-1, 0), (-1, 0), (-1, 0), (-1, 0), (-1, 0), (-1, 0), \
+        basic = [(-1, 0), (-1, 0), (-1, 0), (-1, 0), (-1, 0), (-1, 0), (-1, 0),
                  (0, -1), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1), 'interact']
-        counter = [(0, -1), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1), (-1, 0),\
+        counter = [(0, -1), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1), (-1, 0),
                    (-1, 0), (-1, 0), (-1, 0), (-1, 0), (-1, 0), (-1, 0), (0, -1), 'interact']
-        maze = [(0, 1), (-1, 0), (-1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1), \
-                (0, -1), (0, -1), (-1, 0), (-1, 0), (-1, 0), (0, 1), (0, 1), (0, 1), \
-                (0, 1), (0, 1), (0, 1), (0, 1), (-1, 0), (-1, 0), (0, -1), (0, -1), \
+        maze = [(0, 1), (-1, 0), (-1, 0), (0, -1), (0, -1), (0, -1), (0, -1), (0, -1),
+                (0, -1), (0, -1), (-1, 0), (-1, 0), (-1, 0), (0, 1), (0, 1), (0, 1),
+                (0, 1), (0, 1), (0, 1), (0, 1), (-1, 0), (-1, 0), (0, -1), (0, -1),
                 (0, -1), (0, -1), (0, -1),(0, -1), (0, -1), 'interact']
 
         # checks that the hard coded action paths above are accurate and end in the correct spots
@@ -232,25 +319,23 @@ class TestEntropyComparison(unittest.TestCase):
                 curr_loc[1] += action[1]
         self.assertEqual(end_loc_wo_turn, curr_loc, 'maze')
 
-        # assembles the three paths into a list and sets our parameter ro
+        # assembles the three paths into a list
         paths_to_compare = {'basic': basic, 'counter': counter, 'maze': maze}
-        ro = 5
 
         # calculate and save entropies of each path
         entropies = {}
         for path in paths_to_compare:
-            entropies[path] = calculate_entropy_of_path(paths_to_compare[path], ro)
+            entropies[path] = calculate_entropy_of_path(paths_to_compare[path], ENTROPY_RO)
 
         print(entropies)
 
     def test_entropy_full_path(self):
         # this tests the entropy comparison for the first foundn full path for both agents
-    
+
         # assembles terrains into a list to reduce repetitive code
         terrains = {'basic': self.divided_mtx_basic, 'counter': self.divided_mtx_center_counter, 'maze': self.divided_mtx_keyhole_maze}
         paths = {}
         entropies = {}
-        ro = 5
 
         # analyzes the terrain and retrieves the first possible full action path (first is chosen for simplicity)
         for terrain in terrains:
@@ -259,8 +344,8 @@ class TestEntropyComparison(unittest.TestCase):
 
         # calculates and stores the entropies of each full action path
         for path in paths:
-            entropies[path] = calculate_entropy_of_path(paths[path][0], ro) + \
-                              calculate_entropy_of_path(paths[path][1], ro)
+            entropies[path] = calculate_entropy_of_path(paths[path][0], ENTROPY_RO) + \
+                              calculate_entropy_of_path(paths[path][1], ENTROPY_RO)
 
         print(entropies)
 

--- a/testing/overcooked_test.py
+++ b/testing/overcooked_test.py
@@ -848,9 +848,9 @@ class TestOvercookedEnvironment(unittest.TestCase):
         env.get_rollouts(self.rnd_agent_pair, 5)
 
     def test_starting_position_randomization(self):
-        self.base_mdp = OvercookedGridworld.from_layout_name("cramped_room")
-        start_state_fn = OvercookedGridworld.get_random_start_state_fn(self.base_mdp, random_start_pos=True, rnd_obj_prob_thresh=0.0)
-        env = OvercookedEnv.from_mdp(self.base_mdp, start_state_fn)
+        base_mdp = OvercookedGridworld.from_layout_name("cramped_room")
+        start_state_fn = OvercookedGridworld.get_random_start_state_fn(base_mdp, random_start_pos=True, rnd_obj_prob_thresh=0.0)
+        env = OvercookedEnv.from_mdp(base_mdp, start_state_fn)
         start_state = env.state.players_pos_and_or
         for _ in range(3):
             env.reset()
@@ -858,8 +858,8 @@ class TestOvercookedEnvironment(unittest.TestCase):
             self.assertFalse(np.array_equal(start_state, curr_terrain))
 
     def test_starting_obj_randomization(self):
-        self.base_mdp = OvercookedGridworld.from_layout_name("cramped_room")
-        start_state_fn = lambda : OvercookedGridworld.get_random_start_state_fn(self.base_mdp, random_start_pos=False, rnd_obj_prob_thresh=0.8)
+        base_mdp = OvercookedGridworld.from_layout_name("cramped_room")
+        start_state_fn = OvercookedGridworld.get_random_start_state_fn(base_mdp, random_start_pos=False, rnd_obj_prob_thresh=0.8)
         env = OvercookedEnv.from_mdp(self.base_mdp, start_state_fn)
         start_state = env.state.all_objects_list
         for _ in range(3):
@@ -869,7 +869,7 @@ class TestOvercookedEnvironment(unittest.TestCase):
 
     def test_onion_littering(self):
         base_mdp = OvercookedGridworld.from_layout_name("cramped_room")
-        start_state_fn = lambda : OvercookedGridworld.get_litter_start_state_fn(base_mdp, onion_litter=0.4)()
+        start_state_fn = OvercookedGridworld.get_litter_start_state_fn(base_mdp, onion_litter=0.4)
         env = OvercookedEnv.from_mdp(base_mdp, start_state_fn)
         num_game = 4000
         num_counter = len(env.mdp.get_reachable_counter_locations())
@@ -885,7 +885,7 @@ class TestOvercookedEnvironment(unittest.TestCase):
 
     def test_onion_and_dish_littering(self):
         base_mdp = OvercookedGridworld.from_layout_name("cramped_room")
-        start_state_fn = lambda: OvercookedGridworld.get_litter_start_state_fn(base_mdp, onion_litter=0.3, dish_litter=0.2)()
+        start_state_fn = OvercookedGridworld.get_litter_start_state_fn(base_mdp, onion_litter=0.3, dish_litter=0.2)
         env = OvercookedEnv.from_mdp(base_mdp, start_state_fn)
         num_game = 4000
         num_counter = len(env.mdp.get_reachable_counter_locations())
@@ -907,7 +907,7 @@ class TestOvercookedEnvironment(unittest.TestCase):
 
     def test_onion_and_dish_and_soup_littering(self):
         base_mdp = OvercookedGridworld.from_layout_name("cramped_room")
-        start_state_fn = lambda: OvercookedGridworld.get_litter_start_state_fn(base_mdp, onion_litter=0.3, dish_litter=0.2, soup_1_litter=0.1)()
+        start_state_fn = OvercookedGridworld.get_litter_start_state_fn(base_mdp, onion_litter=0.3, dish_litter=0.2, soup_1_litter=0.1)
         env = OvercookedEnv.from_mdp(base_mdp, start_state_fn)
         num_game = 4000
         num_counter = len(env.mdp.get_reachable_counter_locations())
@@ -934,7 +934,7 @@ class TestOvercookedEnvironment(unittest.TestCase):
 
     def test_onion_and_dish_and_soup_more_littering(self):
         base_mdp = OvercookedGridworld.from_layout_name("cramped_room")
-        start_state_fn = lambda: OvercookedGridworld.get_litter_start_state_fn(base_mdp, onion_litter=0.3, dish_litter=0.2, soup_1_litter=0.1, soup_2_litter=0.15, soup_3_litter=0.12)()
+        start_state_fn = OvercookedGridworld.get_litter_start_state_fn(base_mdp, onion_litter=0.3, dish_litter=0.2, soup_1_litter=0.1, soup_2_litter=0.15, soup_3_litter=0.12)
         env = OvercookedEnv.from_mdp(base_mdp, start_state_fn)
         num_game = 4000
         num_counter = len(env.mdp.get_reachable_counter_locations())
@@ -973,7 +973,7 @@ class TestOvercookedEnvironment(unittest.TestCase):
 
     def test_onion_and_dish_and_soup_more_littering_display(self):
         base_mdp = OvercookedGridworld.from_layout_name("cramped_room")
-        start_state_fn = lambda: OvercookedGridworld.get_litter_start_state_fn(base_mdp, onion_litter=0.3, dish_litter=0.2, soup_1_litter=0.1, soup_2_litter=0.15, soup_3_litter=0.12)()
+        start_state_fn = OvercookedGridworld.get_litter_start_state_fn(base_mdp, onion_litter=0.3, dish_litter=0.2, soup_1_litter=0.1, soup_2_litter=0.15, soup_3_litter=0.12)
         env = OvercookedEnv.from_mdp(base_mdp, start_state_fn)
         num_game = 5
 
@@ -1049,7 +1049,6 @@ class TestOvercookedEnvironment(unittest.TestCase):
             env.reset()
             print(env.mdp.state_string(env.state))
             print("-----------------------------------")
-
 
     def test_failing_rnd_layout(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
These changes update the terrain_analysis function in layout_evaluator.py to properly take in a terrain matrix and generate possible action paths for two agents to make a soup.  The terrain_analysis function generates various action paths to make and deliver a 3-onion soup given a layout using various functions and infrastructure in layout_evaluator.py. The returned action paths can then be passed into an entropy function to evaluate the difficulty of a path/layout.

Key changes:

- addition of path_to_actions method that takes in two location paths and a terrain matrix and generates the action paths corresponding to the location paths. Undefined locations are used to determine when agents are performing the 'interact' action, otherwise are labeled as undefined actions.
- addition of path_to_actions_with_padding method that takes in two location paths, a terrain matrix, and two previous locations (one for each agent). This method is similar to the path_to_actions method above with the difference being this method ensures no undefined actions in the action list. This method does this by replacing undefined actions with padding that either pads with stay actions, or in the case in which an agent has a desired end point to pick up an item from a counter, it will pad with actions that will move the agent to its desired position. 
- the OvercookedMLASearchNode has been modified to store action lists and a single previous location for each agent instead of storing location lists as well as converting location lists to action lists to add them on in the update_from_search_node function
- in the perform_mla method, modifications have been made for collision detection and avoidance. Collision avoidance has been set to move the nonprimary agent to an empty neighboring spot if a collision is detected and to not add the mla path if a collision is unavoidable.
- the terrain_analysis function now takes in a terrain_mtx, and runs through the search process to generate possible action paths for the two agents to (possibly) collaboratively make a soup with three onions. Their action paths are returned in a dictionary.
- addition of a calculate_entropy_from_path which takes in an action list and a parameter ro and calculates the entropy of the given path 
- tests have been added to test all the functionality and changes listed above in the layout_evaluator_test.py file

