### PR TITLE
Waypoint Extraction

### DIFF
--- a/src/overcooked_ai_py/mdp/layout_evaluator.py
+++ b/src/overcooked_ai_py/mdp/layout_evaluator.py
@@ -1390,6 +1390,7 @@ def terrain_analysis(terrain_mtx, silent=True, best_only=True):
     # list to store all possible full action paths for each player
     player_1_action_paths = []
     player_2_action_paths = []
+    pairs_of_action_paths_by_total_length = {}
     length_and_entropy_for_joint_paths = []
 
     # list to store waypoints for each possible path
@@ -1438,6 +1439,11 @@ def terrain_analysis(terrain_mtx, silent=True, best_only=True):
             plan_entropy = np.round(calculate_entropy_of_path(connected_action_path_0, ENTROPY_RHO) + \
                               calculate_entropy_of_path(connected_action_path_1, ENTROPY_RHO), decimals=3)
             length_and_entropy_for_joint_paths.append((total_length, plan_entropy))
+
+            if total_length not in pairs_of_action_paths_by_total_length:
+                pairs_of_action_paths_by_total_length[total_length] = [pair_of_action_paths]
+            else:
+                pairs_of_action_paths_by_total_length[total_length].append(pair_of_action_paths)
 
     return_dict = {}
     return_dict['stage score'] = stage_score

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -6,7 +6,7 @@ from overcooked_ai_py.mdp.layout_evaluator import terrain_analysis, path_to_acti
 
 from overcooked_ai_py.mdp.overcooked_env import OvercookedEnv
 from overcooked_ai_py.mdp.overcooked_mdp import OvercookedGridworld
-
+"""
 class TestHandoverEvaluation(unittest.TestCase):
 
     def setUp(self):
@@ -494,7 +494,61 @@ class TestMotionExtractorRealMDP(unittest.TestCase):
             ['X', 'D', 'X', 'S', 'X', 'X'],
         ]
         self.mtx_test_helper(small_keyhole_mtx, verbose=True)
+        """
 
+class TestMLASearchNodeWaypointTracking(unittest.TestCase):
+    def setUp(self):
+        self.divided_mtx = [
+            ['X', 'P', 'X', 'X', 'X', 'X'],
+            ['O', ' ', 'X', ' ', ' ', 'O'],
+            ['X', '1', 'X', '2', ' ', 'X'],
+            ['X', 'D', 'X', 'S', 'X', 'X'],
+        ]
+
+        self.connected_mtx = [
+            ['X', 'P', 'X', 'X', 'X', 'X'],
+            ['O', ' ', ' ', ' ', ' ', 'O'],
+            ['X', '1', ' ', '2', ' ', 'X'],
+            ['X', 'D', 'X', 'S', 'X', 'X'],
+        ]
+
+        self.small_keyhole_mtx = [
+            ['X', 'P', 'X', 'X', 'X', 'X'],
+            ['O', ' ', ' ', ' ', ' ', 'O'],
+            ['X', ' ', 'X', ' ', ' ', 'X'],
+            ['X', '1', 'X', '2', ' ', 'X'],
+            ['X', 'D', 'X', 'S', 'X', 'X'],
+        ]
+
+    def test_divided_waypoints(self):
+        print("testing divided waypoints------------")
+        analysis = terrain_analysis(self.divided_mtx)
+        waypoints = analysis['waypoints']
+        path1 = analysis['player 1 action paths']
+        path2 = analysis['player 2 action paths']
+        for waypoint in waypoints:
+            print("possible waypoints\n", waypoint)
+        print()
+
+    def test_connected_waypoints(self):
+        print("testing connected waypoints------------")
+        analysis = terrain_analysis(self.connected_mtx)
+        waypoints = analysis['waypoints']
+        path1 = analysis['player 1 action paths']
+        path2 = analysis['player 2 action paths']
+        for waypoint in waypoints:
+            print("possible waypoints\n", waypoint)
+        print()
+
+    def test_keyhole_waypoints(self):
+        print("testing keyhole waypoints------------")
+        analysis = terrain_analysis(self.small_keyhole_mtx)
+        waypoints = analysis['waypoints']
+        path1 = analysis['player 1 action paths']
+        path2 = analysis['player 2 action paths']
+        for waypoint in waypoints:
+            print("possible waypoints\n", waypoint)
+        print()
 
 
 if __name__ == '__main__':

--- a/testing/layout_evaluator_test.py
+++ b/testing/layout_evaluator_test.py
@@ -6,7 +6,7 @@ from overcooked_ai_py.mdp.layout_evaluator import terrain_analysis, path_to_acti
 
 from overcooked_ai_py.mdp.overcooked_env import OvercookedEnv
 from overcooked_ai_py.mdp.overcooked_mdp import OvercookedGridworld
-"""
+
 class TestHandoverEvaluation(unittest.TestCase):
 
     def setUp(self):
@@ -494,7 +494,7 @@ class TestMotionExtractorRealMDP(unittest.TestCase):
             ['X', 'D', 'X', 'S', 'X', 'X'],
         ]
         self.mtx_test_helper(small_keyhole_mtx, verbose=True)
-        """
+
 
 class TestMLASearchNodeWaypointTracking(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Edited the layout_evaluator.py to construct and include information about waypoints for paths.

A waypoint is considered to be when an event has happened such as when an onion is picked up or potted, or a soup starts cooking or is delivered. A waypoint entry is of the format [event_name, primary_agent_idx, agent_loc, item_loc]. 
- event_name: the name of the event (ex: 'onion_pickup', 'soup_delivery')
- primary_agent_idx: the index of the agent that executed the event
- agent_loc: the location of the agent when they executed the event
- item_loc: the location of the item needed to execute the event (ex: onion dispenser, pot, dish dispenser)
Both the agent location and item location are needed to determine the event occurrence as neither one is uniquely identifying by itself. 

Changes made:
- OvercookedMLASearchNode: added waypoints field to keep track of waypoints
- perform_mla function: added construction of waypoints in this function
- terrain_analysis function: now returns a list of waypoints for each possible path
- parse_event_name function: given an event_name, parses it to remove unnecessary information and maps it to match the event names that will be used in trajectories generated from human data

