### PR TITLE
Fix setup.py for visualization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='overcooked_ai',
       package_data={
         'overcooked_ai_py' : [
           'data/layouts/*.layout', 'data/planners/*.py', 'data/human_data/*.pickle',
-          'data/graphics/*.png', 'data/graphics/*.json',
+          'data/graphics/*.png', 'data/graphics/*.json', 'data/fonts/*.ttf',
         ],
       },
       install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ setup(name='overcooked_ai',
       keywords=['Overcooked', 'AI', 'Reinforcement Learning'],
       package_dir={"": "src"},
       package_data={
-        'overcooked_ai_py' : ['data/layouts/*.layout', 'data/planners/*.py', 'data/human_data/*.pickle']
+        'overcooked_ai_py' : [
+          'data/layouts/*.layout', 'data/planners/*.py', 'data/human_data/*.pickle',
+          'data/graphics/*.png', 'data/graphics/*.json',
+        ],
       },
       install_requires=[
         'numpy',


### PR DESCRIPTION
Trying to install the new visualization code using `setup.py` currently doesn't work for two reasons:
 1. The `src/overcooked_ai_py/visualization` directory doesn't have an `__init__.py` file. Python still seems to recognize it as a package for imports (maybe because of [implicit namespace packages](https://www.python.org/dev/peps/pep-0420/)?) but the lack of an `__init__.py` file means that the `visualization` package is not installed when `setup.py` is run. I've added an empty `__init__.py` file to fix this. 
 2. The assets needed for visualization (sprites and fonts) are not included in the `package_data` option in `setup.py`, so they are missing in the installed package. I've added them to `package_data` to fix this.

I can confirm that the changes on my fork have fixed issues and running 

    pip install git+https://github.com/cassidylaidlaw/overcooked_ai@master#egg=overcooked-ai

results in an installation with working visualization.