### PR TITLE
 draft: config recipe if not already configured

### DIFF
--- a/src/overcooked_ai_py/mdp/overcooked_mdp.py
+++ b/src/overcooked_ai_py/mdp/overcooked_mdp.py
@@ -22,7 +22,7 @@ class Recipe:
     
     def __new__(cls, ingredients):
         if not cls._configured:
-            raise ValueError("Recipe class must be configured before recipes can be created")
+            cls.configure({})
         # Some basic argument verification
         if not ingredients or not hasattr(ingredients, '__iter__') or len(ingredients) == 0:
             raise ValueError("Invalid input recipe. Must be ingredients iterable with non-zero length")


### PR DESCRIPTION
Added simple change to allow serialisation of Recipe object - #56 

This doesn't seem to break any local tests but will leave here as a placemarker for when a more sophisticated solution is suggested.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202320259519250